### PR TITLE
Enable comment/uncomment selection

### DIFF
--- a/src/Grammars.pkgdef
+++ b/src/Grammars.pkgdef
@@ -1,6 +1,9 @@
 ﻿[$RootKey$\TextMate\Repositories]
 "Pkgdef"="$PackageFolder$\Syntaxes"
 
+[$RootKey$\TextMate\LanguageConfiguration\GrammarMapping]
+"source.pkgdef"="$PackageFolder$\language-configuration.json"
+
 [$RootKey$\ShellFileAssociations\.pkgdef]
 "DefaultIconMoniker"="KnownMonikers.ConfigurationEditor"
 [$RootKey$\ShellFileAssociations\.pkgundef]

--- a/src/PkgdefLanguage.csproj
+++ b/src/PkgdefLanguage.csproj
@@ -56,6 +56,9 @@
     <Content Include="Resources\Icon.png">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="language-configuration.json">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/src/language-configuration.json
+++ b/src/language-configuration.json
@@ -1,0 +1,5 @@
+{
+  "comments": {
+    "lineComment": ";"
+  }
+}


### PR DESCRIPTION
While working on [my own grammar](https://github.com/bricelam/T4Language), I found that **Ctrl+K, C** didn't work in my pkgdef. Then I thought, "Hey, I can fix that!" 😉